### PR TITLE
Reduce log spam in job validator

### DIFF
--- a/src/go/src/rubrik/sqlapp/job/validator.go
+++ b/src/go/src/rubrik/sqlapp/job/validator.go
@@ -317,7 +317,6 @@ func assertNextPageOfJobsHaveArtifacts(
 		if !hasValidArtifactArr[i] {
 			log.Fatalf(ctx, "no valid artifact found for successful job instance: %v", successes[i])
 		}
-		log.Infof(ctx, "Validated artifact for job instance: %v", successes[i])
 	}
 	if len(instances) < limit {
 		return nil


### PR DESCRIPTION
This was responsible for 3284475 of 3709052 log lines over a 10 minute
run of the test.