### PR TITLE
Fix broken check against sql.ErrTxDone

### DIFF
--- a/src/go/src/rubrik/sqlapp/job/wrappedtx.go
+++ b/src/go/src/rubrik/sqlapp/job/wrappedtx.go
@@ -2,9 +2,9 @@ package job
 
 import (
 	"context"
-	"time"
-
+	"database/sql"
 	"strings"
+	"time"
 
 	"github.com/jinzhu/gorm"
 
@@ -12,11 +12,7 @@ import (
 )
 
 func shouldRollback(err error) bool {
-	return err != nil &&
-		!strings.Contains(
-			err.Error(),
-			"sql: Transaction has already been committed or rolled back",
-		)
+	return err != nil && !strings.Contains(err.Error(), sql.ErrTxDone.Error())
 }
 
 type txResult int


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/39840.
Fixes https://github.com/cockroachdb/cockroach/issues/37595.

This was broken when we rebuilt the jobcoordinator binary using go1.12.6 after
https://github.com/scaledata/rksql/commit/1be6eafb4099b27ba51880295d4e8907ff28dcb0.
This upgrade of Go caused us to hit https://github.com/golang/go/commit/5cf3e34f96f0ea975e0ce5fb8a5f3b036a916500#diff-5b3d7257e10f4efeecb9517a1b6d0c28R1882,
which broke the `shouldRollback` function. We now reference the error
variable directly to avoid renaming issues.