### PR TITLE
Retry txns on class 58 ("System") errors

### DIFF
--- a/src/go/src/rubrik/sqlapp/tx.go
+++ b/src/go/src/rubrik/sqlapp/tx.go
@@ -389,8 +389,12 @@ func pqConnectionError(ctx context.Context, e pq.Error) bool {
 			// this as a connection error for purposes of retry.
 			return true
 		}
+		return false
+	case "58":
+		//System Error (external or internal to cockroach)
+		return true
 	case "XX":
-		// Internal Error
+		//Internal Error
 		return true
 	// Currently no retries on these, raise an issue if you see any of these.
 	case "01":
@@ -469,19 +473,16 @@ func pqConnectionError(ctx context.Context, e pq.Error) bool {
 		//Savepoint Exception
 		return false
 	case "40":
-		// Transaction rollback.
+		//Transaction rollback.
 		return false
 	case "42":
-		// Syntax Error or Access rule violation
+		//Syntax Error or Access rule violation
 		return false
 	case "53":
 		//Insufficient resources(low_mem, disk_full, too_many_connections)
 		return false
 	case "55":
 		//Object not in prerequisite state
-		return false
-	case "58":
-		//System Error(External to postgres)
 		return false
 	default:
 		return false


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/36981.
Fixes https://github.com/cockroachdb/cockroach/issues/39618.
Fixes https://github.com/cockroachdb/cockroach/issues/40552.
Fixes https://github.com/cockroachdb/cockroach/issues/41735.

https://github.com/cockroachdb/cockroach/pull/41451 switched two forms
of errors that can be thrown during chaos events over to a new error code
class - 58, internal system errors. This commit updates `pqConnectionError`
to consider this error code class as retry-worthy.